### PR TITLE
Don't use the default-features of futures to avoid pulling in futures-executor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 exclude = ["sample", "sample-webpack", ".github"]
 
 [dependencies]
-futures = "0.3.21"
+futures = { version = "0.3.21", features = ["std", "async-await"], default-features = false }
 js-sys = "0.3.56"
 log = "0.4.16"
 tokio = { version = "1.17.0", features = ["sync"] }


### PR DESCRIPTION
This results in a smaller dependency graph.